### PR TITLE
Fix import of `when` for GHC 9.6

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,7 @@ import Data.Monoid (Any (..), Ap (..))
 import Control.Monad.State
 import Control.Monad.Except
 import Iso.Deriving
+import Control.Monad (when)
 
 main = pure () -- TODO
 


### PR DESCRIPTION
I don’t know how this happened, but apparently base on 9.6 does not have `when` in Prelude anymore.